### PR TITLE
Optional highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Most modern Markdown components are supported, check [the examples](https://arna
 ### Customisation
 Edit the `config` variable in `index.html`.
 
+### Syntax Highlighting
+Uncomment the  [highlight.js](https://github.com/highlightjs/highlight.js/) imports in `index.html`.
+
 ### Components
 Components are visible in every page, and useful for navbars, sidebars and footers.
 
@@ -35,7 +38,7 @@ python -m http.server 8000
 
 ### Dependencies
 - [Marked.js](https://github.com/markedjs/marked/)
-- [highlight.js](https://github.com/highlightjs/highlight.js/)
+- [highlight.js](https://github.com/highlightjs/highlight.js/) (Optional)
 
 ### Todolist
 - [x] Subdir Support

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Edit the `config` variable in `index.html`.
 
 ### Syntax Highlighting
 Uncomment the  [highlight.js](https://github.com/highlightjs/highlight.js/) imports in `index.html`.
+This adds a significant bundle size.
 
 ### Components
 Components are visible in every page, and useful for navbars, sidebars and footers.

--- a/index.html
+++ b/index.html
@@ -11,10 +11,11 @@
 <!-- Marked - Markdown to HTML library -->
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
-<!-- Highlight.js - Syntax Highlighting -->
+<!-- OPTIONAL : Highlight.js - Syntax Highlighting -->
+<!--
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
-<link rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/base16/solarized-dark.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/base16/solarized-dark.min.css">
+-->
 
 <!-- Configure me! -->
 <script>
@@ -319,7 +320,7 @@
         return marked.parse(markdown,
             {
                 baseUrl: "#/",
-                highlight: (code) => hljs.highlightAuto(code).value,
+                highlight: (code) => hljs ? hljs.highlightAuto(code).value : code,
             });
     }
 


### PR DESCRIPTION
This allows much lighter bundle size.
Uncomment the  [highlight.js](https://github.com/highlightjs/highlight.js/) imports in `index.html` to enable.